### PR TITLE
Avoid failing transformation if upstream collection does not have a docs folder, change example in playbooks/

### DIFF
--- a/playbooks/example.yml
+++ b/playbooks/example.yml
@@ -1,37 +1,9 @@
 ---
 - ansible.builtin.import_playbook: ./fqcn_migration.yml
   vars:
-    upstream_name: jws
-    downstream_name: jws
-    upstream_collection_name: middleware_automation
-    downstream_collection_name: redhat
-    project_git_url: 'https://github.com/ansible-middleware/jws'
+    upstream_name: kubevirt
+    downstream_name: kvirt
+    upstream_collection_name: community
+    downstream_collection_name: ansible
+    project_git_url: 'https://github.com/ansible-collections/community.kubevirt.git'
     project_git_version: main
-    # replace galaxy metadata links
-    galaxy:
-      documentation: https://access.redhat.com/documentation/en-us/red_hat_jboss_web_server
-      homepage: https://access.redhat.com/products/red-hat-jboss-web-server
-    # anything inside <!--start {{ <downstream_placeholder>_delete }} --> and <!--end {{ <downstream_placeholder>_delete }} --> will be removed
-    downstream_placeholder_delete:
-      - build_status
-    # anything inside <!--start {{ <downstream_placeholder>_content }} --> and <!--end {{ <downstream_placeholder>_content }} --> will be replaced with content
-    downstream_placeholder_content:
-      - placeholder: ansible_version
-        content: |
-          Red Hat has tested this collection against Ansible versions 2.9.10 or later.
-
-          Red Hat might test the plug-ins and modules that are within a collection with specific Ansible versions only. A collection can contain metadata that identifies these Ansible versions.
-      - placeholder: galaxy_download
-        content: |
-          For demonstration purposes, you can run the collection directly from this folder. However, the proper setup is to download and install the collection from the Red Hat Automation Hub.
-
-          Before you install the collection, you must ensure that your system complies with the following prerequisites:
-            - You have installed the ansible-core package version 2.12 or later on a control node in your system by installing Red Hat Ansible Automation Platform 2.x.
-            - You have updated the ansible.cfg file to use the Red Hat Automation Hub as your *primary source* of Ansible collections.
-          You can install the collection on your Ansible control node by using the following command:
-              $ ansible-galaxy collection install redhat.jws
-      - placeholder: support
-        content: |
-          The redhat.jws collection v{{ galaxy_version | default('0.0.0-dev') }} is released as a [Technology Preview](https://access.redhat.com/support/offerings/techpreview) feature as the [Red Hat Ansible certified content collection for JBoss Web Server](https://console.redhat.com/ansible/automation-hub/repo/published/redhat/jws). If you have any issues or questions related to this collection, please contact <Ansible-middleware-core@redhat.com> or open an issue at https://github.com/ansible-middleware/jws/issues.
-
-          For more information about using this collection, see [Installing JBoss Web Server by using the Red Hat Ansible Certified Content Collection](https://access.redhat.com/documentation/en-us/red_hat_jboss_web_server/5.7/html-single/installing_jboss_web_server_by_using_the_red_hat_ansible_certified_content_collection/index).

--- a/roles/fqcn_migration/tasks/main.yml
+++ b/roles/fqcn_migration/tasks/main.yml
@@ -25,13 +25,16 @@
     apply:
       tags: galaxy
 
+- ansible.builtin.set_fact:
+    path_to_docs_folder: "{{ downstream_project }}/docs"
+
 - ansible.builtin.include_tasks: docs/main.yml
   tags: always
   args:
     apply:
       tags: docs
-  vars:
-    path_to_docs_folder: "{{ downstream_project }}/docs"
+  when:
+    - path_to_docs_folder is exists
 
 - ansible.builtin.include_tasks: plugins/main.yml
   tags: always


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

if the upstream collection does not have a docs folder, the transformation process fails. These changes fixes that and also update the playbook/example.yml to provide a different example than the molecule scenario.

##### ISSUE TYPE
- Bugfix Pull Request