### PR TITLE
Allow to match upstream names with case insensitive flag

### DIFF
--- a/roles/fqcn_migration/README.md
+++ b/roles/fqcn_migration/README.md
@@ -6,8 +6,9 @@ Dependencies
 ------------
 
 The role depends on collections:
-  - name: community.general
-  - name: ansible.posix
+
+- name: community.general
+- name: ansible.posix
 
 To install, `ansible-galaxy collection install -r requirements.yml`
 
@@ -17,33 +18,35 @@ To install, `ansible-galaxy collection install -r requirements.yml`
 Role Variables
 --------------
 
-| Variable | Description | Required |
-|:---------|:------------|:---------|
-|`upstream_name`| The prefix for roles in the upstream collection to transform | `yes` |
-|`downstream_name`| The name of the downstream collection to generate | `yes` |
-|`project_git_url`| If provided, the git url used to fetch the upstream project repository | no |
-|`project_git_version`| If provided along with `project_git_url`, the branch to fetch the upstream project from | no |
-
+| Variable              | Description                                                                             | Required |
+|:----------------------|:----------------------------------------------------------------------------------------|:---------|
+| `upstream_name`       | The prefix for roles in the upstream collection to transform                            | `yes`    |
+| `downstream_name`     | The name of the downstream collection to generate                                       | `yes`    |
+| `project_git_url`     | If provided, the git url used to fetch the upstream project repository                  | no       |
+| `project_git_version` | If provided along with `project_git_url`, the branch to fetch the upstream project from | no       |
 
 Role Defaults
 -------------
 
-| Variable | Description | Default |
-|:---------|:------------|:--------|
-|`upstream_collection_name`| Optional name of upstream collection | `{{ upstream_name }}` |
-|`upstream_namespace`| Name of the upstream namespace to transform | `community` |
-|`downstream_namespace`| Name of the downstream namespace to generate the collection into | `redhat` |
-|`workdir`| Working directory to run the transformation process onto | `{{ lookup('env', 'PWD') }}` |
-|`upstream_projects_dir`| Directory where the upstream project is cloned from git | `{{ workdir }}/upstream` |
-|`downstream_projects_dir`| Directory where the downstream collection will be generated | `{{ workdir }}/downstream` |
-|`skip_setup`| Whether to skip the pre-transformation setup phase | `True` |
-|`post_processors_replacements`| List of { match, replace, file } dicts for post processing replacements. `match` and `replace` are regexes for string replacements while `file` is a regex matcher filtering filenames to post-process | `[]` |
-|`upstream_downstream_collections_map`| List of dependency mappings {upstream_name, downstream_name} for renaming in tasks, galaxy.yml and requirements.yml | `[]` |
+| Variable                              | Description                                                                                                                                                                                            | Default                      |
+|:--------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------|
+| `upstream_collection_name`            | Optional name of upstream collection                                                                                                                                                                   | `{{ upstream_name }}`        |
+| `upstream_namespace`                  | Name of the upstream namespace to transform                                                                                                                                                            | `community`                  |
+| `downstream_namespace`                | Name of the downstream namespace to generate the collection into                                                                                                                                       | `redhat`                     |
+| `workdir`                             | Working directory to run the transformation process onto                                                                                                                                               | `{{ lookup('env', 'PWD') }}` |
+| `upstream_projects_dir`               | Directory where the upstream project is cloned from git                                                                                                                                                | `{{ workdir }}/upstream`     |
+| `downstream_projects_dir`             | Directory where the downstream collection will be generated                                                                                                                                            | `{{ workdir }}/downstream`   |
+| `skip_setup`                          | Whether to skip the pre-transformation setup phase                                                                                                                                                     | `True`                       |
+| `post_processors_replacements`        | List of { match, replace, file } dicts for post processing replacements. `match` and `replace` are regexes for string replacements while `file` is a regex matcher filtering filenames to post-process | `[]`                         |
+| `upstream_downstream_collections_map` | List of dependency mappings {upstream_name, downstream_name} for renaming in tasks, galaxy.yml and requirements.yml                                                                                    | `[]`                         |
+| `case_insensitive_match`              | It acts as a switch to make upstream_name case insensitive for vars replacement in the collection                                                                                                      | `False`                      |
+
 <!--end argument_specs-->
 
 
 Example Playbook
 ----------------
+
 ```
 ---
 - hosts: all

--- a/roles/fqcn_migration/defaults/main.yml
+++ b/roles/fqcn_migration/defaults/main.yml
@@ -24,3 +24,4 @@ downstream_placeholder_delete: []
 downstream_placeholder_content: []
 override_galaxy_version: ''
 excluded_roles_from_downstream: []
+case_insensitive_match: False

--- a/roles/fqcn_migration/meta/argument_specs.yml
+++ b/roles/fqcn_migration/meta/argument_specs.yml
@@ -79,3 +79,7 @@ argument_specs:
                 type: 'list'
                 default: []
                 description: "List of roles to be excluded from final collection"
+            case_insensitive_match:
+                type: 'bool'
+                default: False
+                description: "Set the value to make upstream_name case insensitive for vars replacement in the collection" 

--- a/roles/fqcn_migration/tasks/utils/rename_vars_in_file.yml
+++ b/roles/fqcn_migration/tasks/utils/rename_vars_in_file.yml
@@ -12,7 +12,7 @@
 - name: "Replace all occurences of upstream '{{ upstream_value }}' to downstream '{{ downstream_value }}' in '{{ path_to_file }}'"
   ansible.builtin.replace:
     path: "{{ path_to_file }}"
-    regexp: "{{ upstream_value }}"
+    regexp: "{{ '(?i)' + upstream_value if case_insensitive_match else upstream_value }}"
     replace: "{{ downstream_value }}"
     #validate: "python -c 'import yaml, sys; print(yaml.safe_load(sys.stdin))'"
   when:


### PR DESCRIPTION
##### SUMMARY
Added a new variable `case_insensitive_match` in `fqcn_migration` role, It acts as a switch to make `upstream_name` case insensitive for vars replacement. the default value is "False".

##### ISSUE TYPE
- Bugfix Pull Request
