### PR TITLE
convert_rst_to_md: Use dnf as package manager

### DIFF
--- a/roles/fqcn_migration/tasks/utils/convert_rst_to_md.yml
+++ b/roles/fqcn_migration/tasks/utils/convert_rst_to_md.yml
@@ -3,19 +3,18 @@
   block:
     - ansible.builtin.include_tasks: utils/check_file_exists.yml
   rescue:
-    - ansible.builtin.debug: 
+    - ansible.builtin.debug:
         msg: "File `{{ path_to_file }}` not found."
 
 - name: "Convert {{ path_to_file }} to markdown"
   block:
     - name: Ensure pandoc is present
-      ansible.builtin.yum:
+      ansible.builtin.dnf:
         name: pandoc
-        use_backend: dnf
       become: yes
     - name: Run pandoc to convert file format
       ansible.builtin.command: >
         pandoc --from=rst --to=markdown_strict -o {{ path_to_file | regex_replace('[.]rst$', '.md')}} {{ path_to_file }}
   rescue:
-    - ansible.builtin.debug: 
+    - ansible.builtin.debug:
         msg: "Error running conversion rst->md with pandoc."


### PR DESCRIPTION


##### SUMMARY
Replace ansible.builtin.yum with ansible.builtin.dnf to install pandoc. This avoids issues on modern distributions like Fedora 39.

Also trim trailing whitespace in the file.

Fixes #8 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

`convert_rst_to_md`
