### PR TITLE
Role parameters in README.md migrated using argument specs

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -31,7 +31,6 @@ warn_list:
   - schema[changelog]
   - name[missing]
   - name[play]
-  - name[template]
   - name[casing]
   - no-changed-when
   - task_has_valid_name
@@ -45,6 +44,7 @@ skip_list:
   - vars_should_not_be_used
   - file_is_small_enough
   - jinja[spacing]
+  - name[template]
 
 use_default_rules: true
 parseable: true

--- a/playbooks/example.yml
+++ b/playbooks/example.yml
@@ -1,5 +1,6 @@
 ---
-- ansible.builtin.import_playbook: ./fqcn_migration.yml
+- name: "Example using main playbook"
+  ansible.builtin.import_playbook: ./fqcn_migration.yml
   vars:
     upstream_name: kubevirt
     downstream_name: kvirt

--- a/playbooks/fqcn_migration.yml
+++ b/playbooks/fqcn_migration.yml
@@ -2,8 +2,6 @@
 - name: "FQCN migration process"
   hosts: localhost
   gather_facts: no
-  collections:
-    - community.fqcn_migration
   vars:
     upstream_name: "{{ lookup('env', 'PROJECT_UPSTREAM_NAME') | default('community') }}"
     downstream_name: "{{ lookup('env', 'PROJECT_NAME') | default('ansible') }}"
@@ -49,7 +47,7 @@
 
     - name: "Git clone {{ project_git_url }} into {{ project_root_folder }}"
       ansible.builtin.include_role:
-        name: git
+        name: community.fqcn_migration.git
         tasks_from: clone.yml
       when:
         - project_root_folder is defined
@@ -58,13 +56,13 @@
   tasks:
     - name: "Run FQCN migration"
       ansible.builtin.include_role:
-        name: fqcn_migration
+        name: community.fqcn_migration.fqcn_migration
       tags: always
 
   post_tasks:
     - name: "Perform release (if requested): {{ release_version == '' | ternary('no release version provided', release_version) }}."
       ansible.builtin.include_role:
-        name: fqcn_migration
+        name: community.fqcn_migration.fqcn_migration
         tasks_from: release.yml
       when:
         - release_version is defined and release_version != ""

--- a/roles/fqcn_migration/README.md
+++ b/roles/fqcn_migration/README.md
@@ -22,24 +22,24 @@ Role Variables
 |:----------------------|:----------------------------------------------------------------------------------------|:---------|
 | `upstream_name`       | The prefix for roles in the upstream collection to transform                            | `yes`    |
 | `downstream_name`     | The name of the downstream collection to generate                                       | `yes`    |
-| `project_git_url`     | If provided, the git url used to fetch the upstream project repository                  | no       |
-| `project_git_version` | If provided along with `project_git_url`, the branch to fetch the upstream project from | no       |
+| `project_git_url`     | If provided, the git url used to fetch the upstream project repository                  | `no`     |
+| `project_git_version` | If provided along with `project_git_url`, the branch to fetch the upstream project from | `no`     |
 
 Role Defaults
 -------------
 
-| Variable                              | Description                                                                                                                                                                                            | Default                      |
-|:--------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------|
-| `upstream_collection_name`            | Optional name of upstream collection                                                                                                                                                                   | `{{ upstream_name }}`        |
-| `upstream_namespace`                  | Name of the upstream namespace to transform                                                                                                                                                            | `community`                  |
-| `downstream_namespace`                | Name of the downstream namespace to generate the collection into                                                                                                                                       | `redhat`                     |
-| `workdir`                             | Working directory to run the transformation process onto                                                                                                                                               | `{{ lookup('env', 'PWD') }}` |
-| `upstream_projects_dir`               | Directory where the upstream project is cloned from git                                                                                                                                                | `{{ workdir }}/upstream`     |
-| `downstream_projects_dir`             | Directory where the downstream collection will be generated                                                                                                                                            | `{{ workdir }}/downstream`   |
-| `skip_setup`                          | Whether to skip the pre-transformation setup phase                                                                                                                                                     | `True`                       |
-| `post_processors_replacements`        | List of { match, replace, file } dicts for post processing replacements. `match` and `replace` are regexes for string replacements while `file` is a regex matcher filtering filenames to post-process | `[]`                         |
-| `upstream_downstream_collections_map` | List of dependency mappings {upstream_name, downstream_name} for renaming in tasks, galaxy.yml and requirements.yml                                                                                    | `[]`                         |
-| `case_insensitive_match`              | It acts as a switch to make upstream_name case insensitive for vars replacement in the collection                                                                                                      | `False`                      |
+| Variable              | Description                    | Default  |
+|:----------------------|:-------------------------------|:---------|
+| `upstream_collection_name`            | Optional name of upstream collection                              | `{{ upstream_name }}`        |
+| `upstream_namespace`                  | Name of the upstream namespace to                                 | `community`                  |
+| `downstream_namespace`                | Name of the downstream namespace to generate the collection into  | `ansible`                    |
+| `workdir`                             | Working directory to run the transformation process onto          | `{{ lookup('env', 'PWD') }}` |
+| `upstream_projects_dir`               | Directory where the upstream project is cloned from git           | `{{ workdir }}/upstream`     |
+| `downstream_projects_dir`             | Directory where the downstream collection will be generated       | `{{ workdir }}/downstream`   |
+| `skip_setup`                          | Whether to skip the pre-transformation setup phase                | `True`                       |
+| `post_processors_replacements`        | List of { match, replace, file } dicts for post processing replacements. `match` and `replace` are regexes for string replacements while `file` is a regex matcher filtering filenames to post-process | `[]` |
+| `upstream_downstream_collections_map` | List of dependency mappings {upstream_name, downstream_name} for renaming in tasks, galaxy.yml and requirements.yml  | `[]` |
+| `case_insensitive_match`              | It acts as a switch to make upstream_name case insensitive for vars replacement in the collection  | `False`  |
 
 <!--end argument_specs-->
 

--- a/roles/fqcn_migration/meta/argument_specs.yml
+++ b/roles/fqcn_migration/meta/argument_specs.yml
@@ -3,24 +3,24 @@ argument_specs:
         options:
             upstream_name:
                 type: 'str'
-                required: yes
+                required: true
                 description: "The prefix for roles in the upstream collection to transform"
             downstream_name:
                 type: 'str'
-                required: yes
+                required: true
                 description: "The name of the downstream collection to generate"
             upstream_collection_name:
                 type: 'str'
-                required: no
+                required: false
                 default: "{{ upstream_name }}"
                 description: "Optional name of upstream collection"
             project_git_url:
                 type: 'str'
-                required: no
+                required: false
                 description: "If provided, the git url used to fetch the upstream project repository"
             project_git_version:
                 type: 'str'
-                required: no
+                required: false
                 description: "If provided along project_git_url, the branch to fetch the upstream project from"
             upstream_namespace:
                 type: 'str'
@@ -72,7 +72,7 @@ argument_specs:
                 description: "List of placeholder comments used to add/replace downstream documentation snippets. List of dict(placeholder:str,content:str)"
             override_galaxy_version:
                 type: 'str'
-                required: no
+                required: false
                 default: ''
                 description: 'Set to override value of downstream version read from galaxy.yml'
             excluded_roles_from_downstream:
@@ -82,4 +82,18 @@ argument_specs:
             case_insensitive_match:
                 type: 'bool'
                 default: False
-                description: "Set the value to make upstream_name case insensitive for vars replacement in the collection" 
+                description: "Set the value to make upstream_name case insensitive for vars replacement in the collection"
+    downstream:
+        options:
+            case_insensitive_match:
+                type: 'bool'
+                default: True
+                description: "Set the value to make upstream_name case insensitive for vars replacement in the collection"
+            upstream_namespace:
+                type: 'str'
+                default: "ansible"
+                description: "Name of the upstream namespace to transform, but different"
+            downstream_namespace:
+                type: 'str'
+                default: "acme"
+                description: "Name of the downstream namespace to generate the collection into, also different"

--- a/roles/fqcn_migration/meta/main.yml
+++ b/roles/fqcn_migration/meta/main.yml
@@ -1,10 +1,7 @@
 ---
-collections:
-  - community.fqcn_migration
-
 galaxy_info:
   role_name: fqcn_migration
-  namespace: community.fqcn_migration
+  namespace: community
   author: Romain Pelisse
   description: Role designed to transform a collection from upstream to downstream
   company: Red Hat, Inc.
@@ -16,7 +13,8 @@ galaxy_info:
   platforms:
    - name: EL
      versions:
-     - 8
+      - "8"
+      - "9"
 
   galaxy_tags:
     - redhat

--- a/roles/fqcn_migration/tasks/copy_upstream_collection.yml
+++ b/roles/fqcn_migration/tasks/copy_upstream_collection.yml
@@ -1,12 +1,13 @@
 ---
-- ansible.builtin.assert:
+- name: "Check parameters"
+  ansible.builtin.assert:
     that:
       - src is defined
       - dest is defined
     quiet: true
     fail_msg: 'Missing required parameters'
 
-- name: "rsync {{ src }} to {{ dest }}"
+- name: "Run rsync {{ src }} to {{ dest }}"
   ansible.posix.synchronize:
     src: "{{ src }}"
     dest: "{{ dest }}"

--- a/roles/fqcn_migration/tasks/docs/argument_specs.yml
+++ b/roles/fqcn_migration/tasks/docs/argument_specs.yml
@@ -1,0 +1,29 @@
+---
+- name: "Override upstream with downstream defaults in '{{ path_to_file }}'"
+  ansible.builtin.replace:
+    dest: "{{ path_to_file }}"
+    regexp: "^[|] ?`{{ downstream_default.key }}` ?[|].*$"
+    replace: "|`{{ downstream_default.key }}`| {{ downstream_default.value.description }} | `{{ downstream_default.value.default | string }}` |"
+  when:
+    - downstream_defaults | length > 0
+    - path_to_file is exists
+    - downstream_default.value is defined and downstream_default.value.default is defined
+  loop: "{{ downstream_defaults | default({}) | dict2items | default([]) }}"
+  loop_control:
+    loop_var: downstream_default
+  register: replacements
+- name: "Add parameters that exist only downstream"
+  ansible.builtin.replace:
+    dest: "{{ path_to_file }}"
+    regexp: '(?m)(Default ?[|]\n*?[|]:?-*[|]:?-*[|]:?-*[|]\n)'
+    replace: '\1|`{{ downstream_default.key }}`| {{ downstream_default.value.description }} | `{{ downstream_default.value.default | string }}` |\n'
+    after: '<!--start argument_specs-->'
+    before: "`{{ (replacements.results | selectattr('changed', 'equalto', True) | first).downstream_default.key }}`"
+  loop: "{{ downstream_defaults | default({}) | dict2items | default([]) }}"
+  loop_control:
+    loop_var: downstream_default
+  when:
+    - not (replacements.results | selectattr('downstream_default.key', 'equalto', downstream_default.key) | first).changed
+    - downstream_defaults | length > 0
+    - path_to_file is exists
+    - downstream_default.value is defined and downstream_default.value.default is defined

--- a/roles/fqcn_migration/tasks/docs/main.yml
+++ b/roles/fqcn_migration/tasks/docs/main.yml
@@ -1,5 +1,6 @@
 ---
-- ansible.builtin.assert:
+- name: "Check parameters"
+  ansible.builtin.assert:
     that:
       - path_to_docs_folder is defined
       - upstream_namespace is defined
@@ -7,23 +8,27 @@
     quiet: True
     fail_msg: "Missing required parameter."
 
-- ansible.builtin.include_tasks: utils/check_dir_exists.yml
+- name: "Check directories"
+  ansible.builtin.include_tasks: utils/check_dir_exists.yml
   vars:
     path_to_dir: "{{ path_to_docs_folder }}"
 
-- ansible.builtin.find:
+- name: "Lookup doc file candidates"
+  ansible.builtin.find:
     paths: "{{ path_to_docs_folder }}"
     file_type: file
     recurse: yes
     patterns: '*.yml,*.rst,*.md'
   register: docs
 
-- ansible.builtin.include_tasks: docs/rename_name_and_namespace.yml
+- name: "Include rename tasks"
+  ansible.builtin.include_tasks: docs/rename_name_and_namespace.yml
   vars:
     path_to_file: "{{ item.path }}"
   loop: "{{ docs.files }}"
 
-- ansible.builtin.find:
+- name: "Lookup doc file candidates for placeholders"
+  ansible.builtin.find:
     paths: "{{ path_to_docs_folder | dirname }}"
     recurse: yes
     file_type: file
@@ -31,7 +36,8 @@
     contains: "^<!--start.*"
   register: markdown
 
-- ansible.builtin.include_tasks: docs/placeholders.yml
+- name: "Include placeholder replacement tasks"
+  ansible.builtin.include_tasks: docs/placeholders.yml
   vars:
     path_to_file: "{{ item.path }}"
   loop: "{{ markdown.files }}"

--- a/roles/fqcn_migration/tasks/docs/rename_name_and_namespace.yml
+++ b/roles/fqcn_migration/tasks/docs/rename_name_and_namespace.yml
@@ -7,12 +7,14 @@
     quiet: True
     fail_msg: "Missing required parameters."
 
-- ansible.builtin.include_tasks: utils/rename_vars_in_file.yml
+- name: "Include rename vars in file (name)"
+  ansible.builtin.include_tasks: utils/rename_vars_in_file.yml
   vars:
     upstream_value: "{{ upstream_name }}"
     downstream_value: "{{ downstream_name }}"
 
-- ansible.builtin.include_tasks: utils/rename_vars_in_file.yml
+- name: "Include rename vars in file (namespace)"
+  ansible.builtin.include_tasks: utils/rename_vars_in_file.yml
   vars:
     upstream_value: "{{ upstream_namespace }}"
     downstream_value: "{{ downstream_namespace }}"

--- a/roles/fqcn_migration/tasks/molecule.yml
+++ b/roles/fqcn_migration/tasks/molecule.yml
@@ -1,16 +1,19 @@
 ---
-- ansible.builtin.find:
+- name: "Lookup molecule files"
+  ansible.builtin.find:
     paths: "{{ molecule_dir }}"
     recurse: yes
     patterns: '*.yml,*.j2'
   register: molecule_yaml
 
-- ansible.builtin.include_tasks: roles/replace_deps_to_upstream_name_to_downstream.yml
+- name: "Include replace deps tasks"
+  ansible.builtin.include_tasks: roles/replace_deps_to_upstream_name_to_downstream.yml
   vars:
     path_to_file: "{{ item.path }}"
   loop: "{{ molecule_yaml.files }}"
 
-- ansible.builtin.include_tasks: utils/replace_name_and_namespace.yml
+- name: "Include replace tasks"
+  ansible.builtin.include_tasks: utils/replace_name_and_namespace.yml
   vars:
     path_to_file: "{{ item.path }}"
   loop: "{{ molecule_yaml.files }}"

--- a/roles/fqcn_migration/tasks/playbooks/main.yml
+++ b/roles/fqcn_migration/tasks/playbooks/main.yml
@@ -1,12 +1,14 @@
 ---
-- assert:
+- name: "Check parameters"
+  ansible.builtin.assert:
     that:
       - project_root_folder is defined
       - downstream_project is defined
     quiet: True
     fail_msg: "Missing required parameters."
 
-- set_fact:
+- name: "Set parameters"
+  ansible.builtin.set_fact:
     path_to_playbooks_dir: "{{ project_root_folder }}/playbooks"
     path_to_playbooks_dir_dest: "{{ downstream_project }}/playbooks"
 
@@ -15,7 +17,10 @@
     path: "{{ path_to_playbooks_dir }}"
   register: is_playbook_dir
 
-- block:
+- name: "Handle playbooks"
+  when:
+    - is_playbook_dir.stat.exists
+  block:
     - name: "List all playbooks within {{ path_to_playbooks_dir_dest }}"
       ansible.builtin.find:
         paths: "{{ path_to_playbooks_dir_dest }}"
@@ -29,8 +34,6 @@
       loop: "{{ downstream_playbooks.files }}"
       loop_control:
         loop_var: playbook_file
-  when:
-    - is_playbook_dir.stat.exists
 
 - name: "List all roles within {{ downstream_project }}/roles"
   ansible.builtin.find:
@@ -39,7 +42,8 @@
     file_type: directory
   register: downstream_roles
 
-- assert:
+- name: "Check parameters"
+  ansible.builtin.assert:
     that:
       - downstream_roles is defined
     quiet: True

--- a/roles/fqcn_migration/tasks/roles/process_role.yml
+++ b/roles/fqcn_migration/tasks/roles/process_role.yml
@@ -56,7 +56,7 @@
   ansible.builtin.set_fact:
     downstream_role_path: "{{ downstream_project }}/roles/{{ downstream_rolename }}"
 
-- name: "Rename role '{{ rolename }}' from {{ role_folder.path }} to {{ downstream_project }}/roles//{{ downstream_rolename }}"
+- name: "Rename role '{{ rolename }}' from {{ role_folder.path }} to {{ downstream_project }}/roles/{{ downstream_rolename }}"
   ansible.builtin.shell: |
     git mv roles/{{ rolename }} roles/{{ downstream_rolename }}
   args:
@@ -68,3 +68,20 @@
   ansible.builtin.include_tasks: roles/rewrite_role_vars.yml
   vars:
     path_role_folder: "{{ downstream_role_path }}"
+
+- name: "Lookup doc file candidates for argument specs in {{ downstream_role_path }}"
+  ansible.builtin.find:
+    paths: "{{ downstream_role_path }}"
+    recurse: yes
+    file_type: file
+    patterns: 'README[.][Mm][Dd]'
+    contains: "^[|] ?`"
+  register: markdown
+
+- name: "Include argument specs doc replacement tasks"
+  ansible.builtin.include_tasks: ../docs/argument_specs.yml
+  vars:
+    path_to_file: "{{ markdownfile.path }}"
+  loop: "{{ markdown.files }}"
+  loop_control:
+    loop_var: markdownfile

--- a/roles/fqcn_migration/tasks/roles/switch_role_dependency_to_downstream.yml
+++ b/roles/fqcn_migration/tasks/roles/switch_role_dependency_to_downstream.yml
@@ -1,15 +1,15 @@
 ---
-- assert:
+- ansible.builtin.assert:
     that:
       - path_to_meta_main_yml is defined
     quiet: true
     fail_msg: 'Missing required parameter.'
 
-- stat:
+- ansible.builtin.stat:
     path: "{{ path_to_meta_main_yml }}"
   register: is_meta_main_yml
 
-- assert:
+- ansible.builtin.assert:
     that:
       - is_meta_main_yml is defined
       - is_meta_main_yml.stat is defined

--- a/roles/fqcn_migration/tasks/utils/check_file_exists.yml
+++ b/roles/fqcn_migration/tasks/utils/check_file_exists.yml
@@ -1,5 +1,5 @@
 ---
-- assert:
+- ansible.builtin.assert:
     that:
       - path_to_file is defined
       - path_to_file is exists

--- a/roles/fqcn_migration/tasks/utils/check_required_parameters.yml
+++ b/roles/fqcn_migration/tasks/utils/check_required_parameters.yml
@@ -1,5 +1,5 @@
 ---
-- assert:
+- ansible.builtin.assert:
     that:
       - upstream_namespace is defined and upstream_namespace != ""
       - upstream_name is defined and upstream_name != ""

--- a/roles/fqcn_migration/tasks/utils/rename_vars_in_file.yml
+++ b/roles/fqcn_migration/tasks/utils/rename_vars_in_file.yml
@@ -1,10 +1,10 @@
 ---
-- set_fact:
+- ansible.builtin.set_fact:
     upstream_value: "{{ upstream_name }}"
   when:
     - not upstream_value is defined
 
-- set_fact:
+- ansible.builtin.set_fact:
     downstream_value: "{{ downstream_name }}"
   when:
     - not downstream_value is defined

--- a/roles/fqcn_migration/tasks/utils/rename_vars_in_file_with_override.yml
+++ b/roles/fqcn_migration/tasks/utils/rename_vars_in_file_with_override.yml
@@ -1,10 +1,10 @@
 ---
-- set_fact:
+- ansible.builtin.set_fact:
     upstream_value: "{{ upstream_name }}"
   when:
     - not upstream_value is defined
 
-- set_fact:
+- ansible.builtin.set_fact:
     downstream_value: "{{ downstream_name }}"
   when:
     - not downstream_value is defined


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `meta/argument_specs.yml` from upstream roles is already used to define new defaults / override existing parameters using the `downstream` entrypoint. This change make use of the same definitions to replace parameter documentation in the role/README.md 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
README replacements using argument_specs.yml definitions

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Given the README.md snippet:

```
[...]

<!--start argument_specs-->

| Variable              | Description                    | Default  |
|:----------------------|:-------------------------------|:---------|
| `upstream_collection_name`     | Optional name of upstream collection   | `{{ upstream_name }}`    |
| `upstream_namespace`    | Name of the upstream namespace to   | `community`      |

```

and the meta/argument_specs.yml

```
argument_specs:
    main:
        options:
            upstream_namespace:
                type: 'str'
                default: "community"
                description: "Name of the upstream namespace to transform"
[...]
    downstream:
        options:
            upstream_namespace:
                type: 'str'
                default: "ansible"
                description: "Name of the upstream namespace to transform, but different"
```

executing the role will result in the following README.md downstream:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
[...]

<!--start argument_specs-->

| Variable              | Description                    | Default  |
|:----------------------|:-------------------------------|:---------|
| `upstream_collection_name` | Optional name of upstream collection                                          | `{{ upstream_name }}` |
| `upstream_namespace`       | Name of the upstream namespace to transform, but different   | `ansible`       |

```
