### PR TITLE
Add parameter plugin_replacement_strict

### DIFF
--- a/roles/fqcn_migration/defaults/main.yml
+++ b/roles/fqcn_migration/defaults/main.yml
@@ -25,3 +25,5 @@ downstream_placeholder_content: []
 override_galaxy_version: ''
 excluded_roles_from_downstream: []
 case_insensitive_match: False
+# set to true to only replace literal "namespace.name"
+plugin_replacement_strict: False

--- a/roles/fqcn_migration/meta/argument_specs.yml
+++ b/roles/fqcn_migration/meta/argument_specs.yml
@@ -83,6 +83,10 @@ argument_specs:
                 type: 'bool'
                 default: False
                 description: "Set the value to make upstream_name case insensitive for vars replacement in the collection"
+            plugin_replacement_strict:
+                default: false
+                description: "set to true to only replace literal 'namespace.name'"
+                type: 'bool'
     downstream:
         options:
             case_insensitive_match:

--- a/roles/fqcn_migration/tasks/plugins/main.yml
+++ b/roles/fqcn_migration/tasks/plugins/main.yml
@@ -12,6 +12,16 @@
   vars:
     path_to_file: "{{ item.path }}"
   loop: "{{ plugin_results.files }}"
+  when: not plugin_replacement_strict
+
+- name: "Include rename vars in files"
+  ansible.builtin.include_tasks: utils/rename_vars_in_file.yml
+  vars:
+    upstream_value: "{{ upstream_namespace }}[.]{{ upstream_name }}"
+    downstream_value: "{{ downstream_namespace }}.{{ downstream_name }}"
+    path_to_file: "{{ item.path }}"
+  loop: "{{ plugin_results.files }}"
+  when: plugin_replacement_strict
 
 - name: Process plugin file
   ansible.builtin.include_tasks: process_plugin.yml

--- a/roles/fqcn_migration/tasks/roles/update_galaxy_yml.yml
+++ b/roles/fqcn_migration/tasks/roles/update_galaxy_yml.yml
@@ -37,6 +37,7 @@
   loop:
     - homepage
     - documentation
+    - description
   when: galaxy is defined and galaxy[item] is defined
 
 - name: "Include tasks - replace deps"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #10 

New parameter `plugin_replacement_strict` indicates that only `<upstream_namespace>.<upstream_name> -> <downstream_namespace>.<downstream_name>` replacements should be executed on plugins/

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

labeled minor_change  because the boolean parameter is default: false (ie. no changes on collection users)
