### PR TITLE
New parameter gitdescribe_galaxy_version

### DIFF
--- a/roles/fqcn_migration/defaults/main.yml
+++ b/roles/fqcn_migration/defaults/main.yml
@@ -23,6 +23,7 @@ downstream_placeholder_delete: []
 # anything inside <!--start {{ downstream_placeholder_content }} --> and <!--end {{ downstream_placeholder_content }} --> will be replaced with content
 downstream_placeholder_content: []
 override_galaxy_version: ''
+gitdescribe_galaxy_version: false
 excluded_roles_from_downstream: []
 case_insensitive_match: False
 # set to true to only replace literal "namespace.name"

--- a/roles/fqcn_migration/meta/argument_specs.yml
+++ b/roles/fqcn_migration/meta/argument_specs.yml
@@ -75,6 +75,10 @@ argument_specs:
                 required: false
                 default: ''
                 description: 'Set to override value of downstream version read from galaxy.yml'
+            gitdescribe_galaxy_version:
+                default: false
+                type: 'bool'
+                description: 'Whether to override the galaxy version using the output of git describe command'
             excluded_roles_from_downstream:
                 type: 'list'
                 default: []

--- a/roles/fqcn_migration/tasks/roles/update_galaxy_yml.yml
+++ b/roles/fqcn_migration/tasks/roles/update_galaxy_yml.yml
@@ -10,7 +10,9 @@
 
 - name: "Slurp galaxy collection version"
   ansible.builtin.set_fact:
-    galaxy_version: "{{ override_galaxy_version | default((galaxy_yml.content | b64decode | from_yaml)['version'], true) }}"
+    galaxy_version: "{{ override_galaxy_version \
+                      | default(git_describe_version \
+                      | default((galaxy_yml.content | b64decode | from_yaml)['version'], true), true) }}"
 
 - name: "Copy galaxy.yml from {{ upstream_project }} to {{ downstream_project }}"
   ansible.builtin.copy:

--- a/roles/git/tasks/clone.yml
+++ b/roles/git/tasks/clone.yml
@@ -7,7 +7,7 @@
     quiet: True
     fail_msg: "Missing required parameters"
 
-- name: "Git clone {{ project_git_url }} [{{ project_git_version }}] into {{ project_root_folder }}"
+- name: "Git clone {{ project_git_url }} [{{ project_git_version }}] into {{ project_root_folder }}]"
   ansible.builtin.git:
     repo: "{{ project_git_url }}"
     dest: "{{ project_root_folder }}"
@@ -17,15 +17,14 @@
   delay: 15
   until: not git_clone_res.failed
 
-- name: "Git clone {{ project_git_url }} [{{ project_git_version }}] into {{ project_root_folder }}"
+- name: "Run git describe for galaxy.yml version override"
   ansible.builtin.command: git describe    # noqa command-instead-of-module
   args:
     chdir: "{{ project_root_folder }}"
   changed_when: false
-  failed_when: false
   register: git_describe_result
-  when: gitdescribe_galaxy_version
+  when: gitdescribe_galaxy_version is defined and gitdescribe_galaxy_version
   
 - name: "Set git_describe_version"
-  ansible.builtin.set_fact:  
-    git_describe_version: "{{ git_describe_result.stdout | default('') }}˝
+  ansible.builtin.set_fact:
+    git_describe_version: "{{ git_describe_result.stdout | default('') }}"

--- a/roles/git/tasks/clone.yml
+++ b/roles/git/tasks/clone.yml
@@ -16,3 +16,16 @@
   retries: 3
   delay: 15
   until: not git_clone_res.failed
+
+- name: "Git clone {{ project_git_url }} [{{ project_git_version }}] into {{ project_root_folder }}"
+  ansible.builtin.command: git describe    # noqa command-instead-of-module
+  args:
+    chdir: "{{ project_root_folder }}"
+  changed_when: false
+  failed_when: false
+  register: git_describe_result
+  when: gitdescribe_galaxy_version
+  
+- name: "Set git_describe_version"
+  ansible.builtin.set_fact:  
+    git_describe_version: "{{ git_describe_result.stdout | default('') }}˝


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
 

A new flag allows to use the output of `git describe` as the override version for galaxy.yml


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request
