### PR TITLE
Revert matches also applies to docs directory

### DIFF
--- a/roles/fqcn_migration/tasks/docs/rename_name_and_namespace.yml
+++ b/roles/fqcn_migration/tasks/docs/rename_name_and_namespace.yml
@@ -19,3 +19,13 @@
   vars:
     upstream_value: "{{ upstream_namespace }}"
     downstream_value: "{{ downstream_namespace }}"
+
+- name: Revert false positive matches
+  ansible.builtin.include_tasks: utils/rename_vars_in_file.yml
+  vars:
+    upstream_value: "{{ string.match }}"
+    downstream_value: "{{ string.replace }}"
+  loop: "{{ post_processors_replacements | default([]) }}"
+  loop_control:
+    loop_var: string
+  when: string.file is not defined or path_to_file is regex(string.file)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`post_processors_replacements` is only executed against files in roles/. It should be applied to docs/ as well (for code examples, snippets, and so on)


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request



