### PR TITLE
release: fix branch being pushed for release

### DIFF
--- a/roles/fqcn_migration/tasks/release.yml
+++ b/roles/fqcn_migration/tasks/release.yml
@@ -57,5 +57,5 @@
     tasks_from: push.yml
   vars:
     remote_name: downstream
-    local_branch: main
+    local_branch: "{{ tag }}"
     remote_branch: "{{ tag }}"


### PR DESCRIPTION
##### SUMMARY

When performing a release the tag (and associated branch) is not pushed, but main is instead.

##### ISSUE TYPE
- Bugfix Pull Request