### PR TITLE
Add missing replacement of overridden galaxy versions

### DIFF
--- a/roles/fqcn_migration/tasks/roles/update_galaxy_yml.yml
+++ b/roles/fqcn_migration/tasks/roles/update_galaxy_yml.yml
@@ -31,6 +31,13 @@
     # Replace in all other lines, except issues: and repository: as this would break repo links
     - { regexp: "^(\\w*: )((?<!issues: )|(?<!repository: )){{ upstream_namespace }}", replace: "\\1{{ downstream_namespace }}" }
 
+- name: "Replace galaxy version with {{ galaxy_version }}"
+  ansible.builtin.replace:
+    path: "{{ downstream_galaxy_yml }}"
+    regexp: "^version: .*"
+    replace: "{{ item }}: \"{{ galaxy_version }}\""
+  when: galaxy_version != (galaxy_yml.content | b64decode | from_yaml)['version']
+
 - name: "Replace galaxy.yml {{ item }}"
   ansible.builtin.replace:
     path: "{{ downstream_galaxy_yml }}"


### PR DESCRIPTION
##### SUMMARY

The git_describe or version_override parameters have no effect because the actual replacement in galaxy.yml is missing

##### ISSUE TYPE
- Bugfix Pull Request


Fix #20 
